### PR TITLE
Implement B-ViewSchedules

### DIFF
--- a/src/main/java/duke/command/ViewCommand.java
+++ b/src/main/java/duke/command/ViewCommand.java
@@ -9,21 +9,21 @@ import java.time.LocalDate;
 /**
  * Represents a command to display tasks from the task list that happen on a given date.
  */
-public class OnCommand extends Command {
+public class ViewCommand extends Command {
 
     private LocalDate targetDate;
 
     /**
-     * Constructs an OnCommand with the given target date.
+     * Constructs a ViewCommand with the given target date.
      *
      * @param targetDate Target date for which the tasks from the task list will be displayed.
      */
-    public OnCommand(LocalDate targetDate) {
+    public ViewCommand(LocalDate targetDate) {
         this.targetDate = targetDate;
     }
 
     /**
-     * Executes the OnCommand by displaying tasks from
+     * Executes the ViewCommand by displaying tasks from
      * the task list that happen on a given date using Ui.
      *
      * @param tasks TaskList that contains the task list.

--- a/src/main/java/duke/main/Parser.java
+++ b/src/main/java/duke/main/Parser.java
@@ -6,7 +6,7 @@ import duke.command.Command;
 import duke.command.DeleteCommand;
 import duke.command.MarkCommand;
 import duke.command.UnMarkCommand;
-import duke.command.OnCommand;
+import duke.command.ViewCommand;
 import duke.command.ExitCommand;
 import duke.command.ListCommand;
 import duke.command.FindCommand;
@@ -47,11 +47,11 @@ public class Parser {
         } else if(userInput.startsWith("delete")) {
             int num = parseTaskNumber(userInput, "delete");
             return new DeleteCommand(num);
-        } else if (userInput.startsWith("on")) {
-            String dateInput = userInput.replace("on", "").trim();
-            processEmptyDescription(dateInput, "on");
+        } else if (userInput.startsWith("view")) {
+            String dateInput = userInput.replace("view", "").trim();
+            processEmptyDescription(dateInput, "view");
             LocalDate targetDate = parseOnDateTime(dateInput);
-            return new OnCommand(targetDate);
+            return new ViewCommand(targetDate);
         } else if (userInput.startsWith("find")) {
             String findWord = userInput.replace("find", "").trim();
             processEmptyDescription(findWord, "find");

--- a/src/test/java/duke/main/ParserTest.java
+++ b/src/test/java/duke/main/ParserTest.java
@@ -5,7 +5,7 @@ import duke.command.EventCommand;
 import duke.command.ExitCommand;
 import duke.command.ListCommand;
 import duke.command.MarkCommand;
-import duke.command.OnCommand;
+import duke.command.ViewCommand;
 import duke.command.ToDoCommand;
 import duke.command.UnMarkCommand;
 
@@ -24,8 +24,8 @@ public class ParserTest {
         assertTrue(Parser.parse("bye") instanceof ExitCommand, "exit parser passed");
         assertTrue(Parser.parse("list") instanceof ListCommand, "list parser passed");
         assertTrue(Parser.parse("mark 1") instanceof MarkCommand, "mark parser passed");
-        assertTrue(Parser.parse("on Oct 15 2019") instanceof OnCommand, "on parser passed");
-        assertTrue(Parser.parse("on Oct 17 2019") instanceof OnCommand, "on parser passed");
+        assertTrue(Parser.parse("view Oct 15 2019") instanceof ViewCommand, "view parser passed");
+        assertTrue(Parser.parse("view Oct 17 2019") instanceof ViewCommand, "view parser passed");
         assertTrue(Parser.parse("todo go to school") instanceof ToDoCommand, "todo parser passed");
         assertTrue(Parser.parse("unmark 20") instanceof UnMarkCommand, "unmark parser passed");
     }


### PR DESCRIPTION
Current implementation allows users to view their schedule on a specific date using the "on" command.

This features provides a way for users to view tasks on a specific date in the form of a schedule.

Let's,
* modify the OnCommand class and rename it to ViewCommand, refactoring the current code
* modify the Parser class such that the "view" command displays the scheduled tasks on the given date instead of the "on" command
* modify the JUnit test cases in the ParserTest class to account for the modified "view" command and the refactored ViewCommand class